### PR TITLE
feat: signature-aware migrations: drop and recreate functions when their signature changes

### DIFF
--- a/sqlfun/__init__.py
+++ b/sqlfun/__init__.py
@@ -1,1 +1,4 @@
 from .core import SqlFun
+from .parsing import SqlFunParseError
+
+__all__ = ['SqlFun', 'SqlFunParseError']

--- a/sqlfun/core.py
+++ b/sqlfun/core.py
@@ -1,9 +1,10 @@
-import re
 from abc import ABC
 from typing import ClassVar, Optional, Type
 
 from django.db.models.expressions import Func
 from django.db.models.fields import Field
+
+from sqlfun.parsing import SqlFunParseError, parse_function_signature
 
 
 class SqlFun(Func, ABC):
@@ -30,13 +31,10 @@ class SqlFun(Func, ABC):
     @classmethod
     def get_function_name_from_sql(cls) -> str:
         """Get the function name from the SQL definition"""
-
-        pattern = re.compile(r'FUNCTION.+?(\w+).+')
-
-        if match := pattern.search(cls.sql):
-            return match.group(1)
-        else:
-            raise ValueError('Could not determine function name from SQL definition.')
+        try:
+            return parse_function_signature(cls.sql).name
+        except SqlFunParseError as error:
+            raise SqlFunParseError(f'{cls.__name__}: {error}') from error
 
     @classmethod
     def update(cls):

--- a/sqlfun/management/commands/makemigrations.py
+++ b/sqlfun/management/commands/makemigrations.py
@@ -2,6 +2,7 @@
 import django
 from django.core.management.commands.makemigrations import Command as BaseCommand
 
+from sqlfun.parsing import SqlFunParseError
 from sqlfun.utils import make_sqlfun_migrations
 
 
@@ -13,6 +14,12 @@ class Command(BaseCommand):
                 custom_name=options.get('name'),
                 stdout=self.stdout,
                 is_dry_run=options.get('dry_run')
+            )
+        except SqlFunParseError as e:
+            self.stderr.write(f'[sqlfun] Could not parse a function signature: {e}')
+            self.stderr.write(
+                '[sqlfun] No sqlfun migration was generated. Fix the SQL '
+                'definition above and re-run makemigrations.'
             )
         except django.db.utils.ProgrammingError:
             self.stderr.write(

--- a/sqlfun/parsing.py
+++ b/sqlfun/parsing.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+PARAM_MODES = ('in', 'out', 'inout', 'variadic')
+
+CREATE_FUNCTION_RE = re.compile(
+    r'CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+'
+    r'(?P<name>(?:"[^"]+"|[\w$]+)(?:\s*\.\s*(?:"[^"]+"|[\w$]+))?)\s*\(',
+    re.IGNORECASE,
+)
+
+RETURNS_RE = re.compile(r'\s*RETURNS\s+', re.IGNORECASE)
+
+RETURNS_TABLE_RE = re.compile(r'TABLE\s*\(', re.IGNORECASE)
+
+# Keywords that can follow the RETURNS type in a CREATE FUNCTION statement.
+RETURNS_TERMINATORS = frozenset({
+    'as', 'begin', 'called', 'cost', 'immutable', 'language', 'leakproof',
+    'not', 'parallel', 'rows', 'security', 'set', 'stable', 'strict',
+    'support', 'transform', 'volatile', 'window',
+})
+
+
+class SqlFunParseError(Exception):
+    """Raised when a function signature cannot be parsed from a SQL definition."""
+
+
+@dataclass(frozen=True)
+class Parameter:
+    definition: str
+    mode: str = 'in'
+
+
+@dataclass(frozen=True)
+class FunctionSignature:
+    name: str
+    parameters: tuple[Parameter, ...]
+    returns: str
+
+    @property
+    def drop_clause(self) -> str:
+        """Render ``name(input params)`` in the form DROP FUNCTION accepts.
+
+        OUT parameters are not part of a function's identity and must be
+        omitted; DEFAULT expressions were already stripped during parsing.
+        """
+        parts = []
+        for parameter in self.parameters:
+            if parameter.mode == 'out':
+                continue
+            prefix = f'{parameter.mode} ' if parameter.mode in ('inout', 'variadic') else ''
+            parts.append(f'{prefix}{parameter.definition}')
+        return f'{self.name}({", ".join(parts)})'
+
+
+def parse_function_signature(sql: str) -> FunctionSignature:
+    match = CREATE_FUNCTION_RE.search(sql)
+    if not match:
+        raise SqlFunParseError(
+            'Could not parse a CREATE FUNCTION statement with a parenthesized '
+            f'parameter list from SQL definition:\n{sql}'
+        )
+    name = _normalize_identifier(match.group('name'))
+    parameter_text, params_end = _extract_parenthesized(sql, match.end() - 1)
+    parameters = tuple(
+        _parse_parameter(part) for part in _split_top_level(parameter_text)
+    )
+    returns = _parse_returns(sql, params_end)
+    return FunctionSignature(name=name, parameters=parameters, returns=returns)
+
+
+def _normalize_identifier(name: str) -> str:
+    name = re.sub(r'\s*\.\s*', '.', name.strip())
+    if '"' in name:
+        return name
+    return name.lower()
+
+
+def _normalize(text: str) -> str:
+    """Lowercase outside double quotes, collapse whitespace, and remove
+    spaces adjacent to parens, brackets, and commas."""
+    parts = re.split(r'("[^"]*")', text)
+    lowered = ''.join(
+        part if part.startswith('"') else part.lower()
+        for part in parts
+    )
+    collapsed = re.sub(r'\s+', ' ', lowered).strip()
+    return re.sub(r'\s*([(),\[\]])\s*', r'\1', collapsed)
+
+
+def _extract_parenthesized(sql: str, open_index: int) -> tuple[str, int]:
+    """Return the text inside the paren group opening at ``open_index`` and
+    the index just past its closing paren. Respects single-quoted strings."""
+    depth = 0
+    in_string = False
+    for i in range(open_index, len(sql)):
+        char = sql[i]
+        if in_string:
+            if char == "'":
+                in_string = False
+        elif char == "'":
+            in_string = True
+        elif char == '(':
+            depth += 1
+        elif char == ')':
+            depth -= 1
+            if depth == 0:
+                return sql[open_index + 1:i], i + 1
+    raise SqlFunParseError(f'Unbalanced parentheses in SQL definition:\n{sql}')
+
+
+def _split_top_level(text: str) -> list[str]:
+    """Split on commas that are not nested inside parens, brackets, or
+    single-quoted strings."""
+    if not text.strip():
+        return []
+    parts = []
+    current = []
+    depth = 0
+    in_string = False
+    for char in text:
+        if in_string:
+            current.append(char)
+            if char == "'":
+                in_string = False
+        elif char == "'":
+            in_string = True
+            current.append(char)
+        elif char in '([':
+            depth += 1
+            current.append(char)
+        elif char in ')]':
+            depth -= 1
+            current.append(char)
+        elif char == ',' and depth == 0:
+            parts.append(''.join(current).strip())
+            current = []
+        else:
+            current.append(char)
+    parts.append(''.join(current).strip())
+    return parts
+
+
+def _strip_default(text: str) -> str:
+    """Remove a trailing ``DEFAULT expr`` or ``= expr`` from a parameter."""
+    depth = 0
+    in_string = False
+    for i, char in enumerate(text):
+        if in_string:
+            if char == "'":
+                in_string = False
+        elif char == "'":
+            in_string = True
+        elif char in '([':
+            depth += 1
+        elif char in ')]':
+            depth -= 1
+        elif depth == 0:
+            if char == '=':
+                return text[:i].strip()
+            if char in 'dD' and _matches_keyword(text, i, 'default'):
+                return text[:i].strip()
+    return text.strip()
+
+
+def _matches_keyword(text: str, start: int, keyword: str) -> bool:
+    end = start + len(keyword)
+    if text[start:end].lower() != keyword:
+        return False
+    before = text[start - 1] if start > 0 else ' '
+    after = text[end] if end < len(text) else ' '
+    is_word_char = lambda c: c.isalnum() or c == '_'  # noqa: E731
+    return not is_word_char(before) and not is_word_char(after)
+
+
+def _parse_parameter(text: str) -> Parameter:
+    without_default = _strip_default(text)
+    if not without_default:
+        raise SqlFunParseError(f'Could not parse function parameter: {text!r}')
+    normalized = _normalize(without_default)
+    first_word, _, rest = normalized.partition(' ')
+    if first_word in PARAM_MODES and rest:
+        return Parameter(definition=rest, mode=first_word)
+    return Parameter(definition=normalized)
+
+
+def _parse_returns(sql: str, start: int) -> str:
+    match = RETURNS_RE.match(sql, start)
+    if not match:
+        raise SqlFunParseError(
+            f'Could not find a RETURNS clause in SQL definition:\n{sql}'
+        )
+    table_match = RETURNS_TABLE_RE.match(sql, match.end())
+    if table_match:
+        columns, _ = _extract_parenthesized(sql, table_match.end() - 1)
+        return _normalize(f'table({columns})')
+    words = []
+    for word_match in re.finditer(r'\S+', sql[match.end():]):
+        word = word_match.group()
+        stripped = word.rstrip(';')
+        if not stripped or stripped.lower() in RETURNS_TERMINATORS or stripped.startswith('$'):
+            break
+        words.append(stripped)
+        if stripped != word:
+            break
+    if not words:
+        raise SqlFunParseError(
+            f'Could not parse the RETURNS clause in SQL definition:\n{sql}'
+        )
+    return _normalize(' '.join(words))

--- a/sqlfun/parsing.py
+++ b/sqlfun/parsing.py
@@ -20,8 +20,8 @@ RETURNS_TABLE_RE = re.compile(r'TABLE\s*\(', re.IGNORECASE)
 # Keywords that can follow the RETURNS type in a CREATE FUNCTION statement.
 RETURNS_TERMINATORS = frozenset({
     'as', 'begin', 'called', 'cost', 'external', 'immutable', 'language',
-    'leakproof', 'not', 'parallel', 'returns', 'rows', 'security', 'set',
-    'stable', 'strict', 'support', 'transform', 'volatile', 'window',
+    'leakproof', 'not', 'parallel', 'return', 'returns', 'rows', 'security',
+    'set', 'stable', 'strict', 'support', 'transform', 'volatile', 'window',
 })
 
 

--- a/sqlfun/parsing.py
+++ b/sqlfun/parsing.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+import sqlparse
+
 PARAM_MODES = ('in', 'out', 'inout', 'variadic')
 
 CREATE_FUNCTION_RE = re.compile(
@@ -56,18 +58,28 @@ class FunctionSignature:
 
 
 def parse_function_signature(sql: str) -> FunctionSignature:
-    match = CREATE_FUNCTION_RE.search(sql)
+    # Comments are only meaningful to a human reader, but they are valid
+    # anywhere whitespace is allowed in the statement header and parameter
+    # list, which would otherwise confuse the regex/paren matching below.
+    # strip_comments preserves comment-like text inside dollar-quoted
+    # bodies and single-quoted strings, so it's safe to parse from here on.
+    # Error messages still quote the original ``sql`` since that's what the
+    # caller passed in and will recognize.
+    uncommented = sqlparse.format(sql, strip_comments=True)
+    match = CREATE_FUNCTION_RE.search(uncommented)
     if not match:
         raise SqlFunParseError(
             'Could not parse a CREATE FUNCTION statement with a parenthesized '
             f'parameter list from SQL definition:\n{sql}'
         )
     name = _normalize_identifier(match.group('name'))
-    parameter_text, params_end = _extract_parenthesized(sql, match.end() - 1)
+    parameter_text, params_end = _extract_parenthesized(
+        uncommented, match.end() - 1, original_sql=sql
+    )
     parameters = tuple(
         _parse_parameter(part) for part in _split_top_level(parameter_text)
     )
-    returns = _parse_returns(sql, params_end)
+    returns = _parse_returns(uncommented, params_end, original_sql=sql)
     return FunctionSignature(name=name, parameters=parameters, returns=returns)
 
 
@@ -90,9 +102,16 @@ def _normalize(text: str) -> str:
     return re.sub(r'\s*([(),\[\]])\s*', r'\1', collapsed)
 
 
-def _extract_parenthesized(sql: str, open_index: int) -> tuple[str, int]:
+def _extract_parenthesized(
+    sql: str, open_index: int, original_sql: str | None = None
+) -> tuple[str, int]:
     """Return the text inside the paren group opening at ``open_index`` and
-    the index just past its closing paren. Respects single-quoted strings."""
+    the index just past its closing paren. Respects single-quoted strings.
+
+    ``original_sql`` is quoted in error messages instead of ``sql`` when given,
+    so callers that pass a comment-stripped ``sql`` can still surface the
+    original SQL the caller recognizes.
+    """
     depth = 0
     in_string = False
     for i in range(open_index, len(sql)):
@@ -108,7 +127,7 @@ def _extract_parenthesized(sql: str, open_index: int) -> tuple[str, int]:
             depth -= 1
             if depth == 0:
                 return sql[open_index + 1:i], i + 1
-    raise SqlFunParseError(f'Unbalanced parentheses in SQL definition:\n{sql}')
+    raise SqlFunParseError(f'Unbalanced parentheses in SQL definition:\n{original_sql or sql}')
 
 
 def _split_top_level(text: str) -> list[str]:
@@ -186,15 +205,15 @@ def _parse_parameter(text: str) -> Parameter:
     return Parameter(definition=normalized)
 
 
-def _parse_returns(sql: str, start: int) -> str:
+def _parse_returns(sql: str, start: int, original_sql: str | None = None) -> str:
     match = RETURNS_RE.match(sql, start)
     if not match:
         raise SqlFunParseError(
-            f'Could not find a RETURNS clause in SQL definition:\n{sql}'
+            f'Could not find a RETURNS clause in SQL definition:\n{original_sql or sql}'
         )
     table_match = RETURNS_TABLE_RE.match(sql, match.end())
     if table_match:
-        columns, _ = _extract_parenthesized(sql, table_match.end() - 1)
+        columns, _ = _extract_parenthesized(sql, table_match.end() - 1, original_sql=original_sql)
         return _normalize(f'table({columns})')
     words = []
     for word_match in re.finditer(r'\S+', sql[match.end():]):
@@ -207,6 +226,6 @@ def _parse_returns(sql: str, start: int) -> str:
             break
     if not words:
         raise SqlFunParseError(
-            f'Could not parse the RETURNS clause in SQL definition:\n{sql}'
+            f'Could not parse the RETURNS clause in SQL definition:\n{original_sql or sql}'
         )
     return _normalize(' '.join(words))

--- a/sqlfun/parsing.py
+++ b/sqlfun/parsing.py
@@ -17,13 +17,13 @@ RETURNS_TABLE_RE = re.compile(r'TABLE\s*\(', re.IGNORECASE)
 
 # Keywords that can follow the RETURNS type in a CREATE FUNCTION statement.
 RETURNS_TERMINATORS = frozenset({
-    'as', 'begin', 'called', 'cost', 'immutable', 'language', 'leakproof',
-    'not', 'parallel', 'rows', 'security', 'set', 'stable', 'strict',
-    'support', 'transform', 'volatile', 'window',
+    'as', 'begin', 'called', 'cost', 'external', 'immutable', 'language',
+    'leakproof', 'not', 'parallel', 'returns', 'rows', 'security', 'set',
+    'stable', 'strict', 'support', 'transform', 'volatile', 'window',
 })
 
 
-class SqlFunParseError(Exception):
+class SqlFunParseError(ValueError):
     """Raised when a function signature cannot be parsed from a SQL definition."""
 
 

--- a/sqlfun/utils.py
+++ b/sqlfun/utils.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import re
 from collections import defaultdict
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Optional
 
 import sqlparse
@@ -43,6 +44,17 @@ def _parse_signature(sql: str, context: str) -> FunctionSignature:
         raise SqlFunParseError(f'{context}: {error}') from error
 
 
+def _parse_stored_signature(sql: str, function_name: str) -> FunctionSignature:
+    return _parse_signature(
+        sql,
+        context=(
+            f'Stored definition for {function_name!r} could not be parsed. '
+            'If it predates signature parsing, delete its SqlFunDefinition '
+            'row and re-run makemigrations'
+        ),
+    )
+
+
 def get_app_name(filepath: str) -> str | None:
     """
     Returns the name of the Django app that contains the module at the given filepath.
@@ -65,73 +77,73 @@ def get_app_label_for_cls(sqlfun_cls: SqlFun) -> str | None:
     return sqlfun_cls.app_label or get_app_name(inspect.getfile(sqlfun_cls))
 
 
-def get_migration_operations() -> dict[str, list[migrations.RunSQL]]:
-    migration_operations = defaultdict(list)
+def _build_operation_for_function(sqlfun_cls: SqlFun) -> migrations.RunSQL | None:
+    """Returns the operation for a registered function, or None if it is unchanged."""
+    current_sql = normalize_sql(sqlfun_cls.sql)
+    previous_sql = get_previous_sql_definition(sqlfun_cls)
 
-    for sqlfun_cls in SqlFun._registry:
-        app_label = get_app_label_for_cls(sqlfun_cls)
-        current_sql = normalize_sql(sqlfun_cls.sql)
-        previous_sql = get_previous_sql_definition(sqlfun_cls)
+    if current_sql == previous_sql:
+        return None
 
-        if current_sql == previous_sql:
-            continue
+    current_signature = _parse_signature(
+        sqlfun_cls.sql,
+        context=f'SqlFun class {sqlfun_cls.__name__!r}',
+    )
 
-        current_signature = _parse_signature(
-            sqlfun_cls.sql,
-            context=f'SqlFun class {sqlfun_cls.__name__!r}',
+    if previous_sql is None:
+        return migrations.RunSQL(
+            sql=sqlfun_cls.sql,
+            reverse_sql=f'DROP FUNCTION IF EXISTS {current_signature.drop_clause};',
         )
 
-        if previous_sql is None:
-            operation = migrations.RunSQL(
-                sql=sqlfun_cls.sql,
-                reverse_sql=f'DROP FUNCTION IF EXISTS {current_signature.drop_clause};',
-            )
-        else:
-            previous_signature = _parse_signature(
-                previous_sql,
-                context=(
-                    f'Stored definition for {current_signature.name!r} could not be '
-                    'parsed. If it predates signature parsing, delete its '
-                    'SqlFunDefinition row and re-run makemigrations'
-                ),
-            )
-            if current_signature == previous_signature:
-                operation = migrations.RunSQL(
-                    sql=sqlfun_cls.sql,
-                    reverse_sql=previous_sql,
-                )
-            else:
-                operation = migrations.RunSQL(
-                    sql=[
-                        f'DROP FUNCTION IF EXISTS {previous_signature.drop_clause};',
-                        sqlfun_cls.sql,
-                    ],
-                    reverse_sql=[
-                        f'DROP FUNCTION IF EXISTS {current_signature.drop_clause};',
-                        previous_sql,
-                    ],
-                )
+    previous_signature = _parse_stored_signature(previous_sql, current_signature.name)
 
-        migration_operations[app_label].append(operation)
+    if current_signature == previous_signature:
+        return migrations.RunSQL(
+            sql=sqlfun_cls.sql,
+            reverse_sql=previous_sql,
+        )
 
+    return migrations.RunSQL(
+        sql=[
+            f'DROP FUNCTION IF EXISTS {previous_signature.drop_clause};',
+            sqlfun_cls.sql,
+        ],
+        reverse_sql=[
+            f'DROP FUNCTION IF EXISTS {current_signature.drop_clause};',
+            previous_sql,
+        ],
+    )
+
+
+def _build_deleted_function_operations() -> Iterator[tuple[str | None, migrations.RunSQL]]:
+    """Yields (app_label, drop operation) for stored functions that are no longer registered."""
     registered_names = {
         func.get_function_name_from_sql() for func in SqlFun._registry
     }
     for stored_function in SqlFunDefinition.objects.all():
-        stored_signature = _parse_signature(
+        stored_signature = _parse_stored_signature(
             stored_function.sql_definition,
-            context=(
-                f'Stored definition for {stored_function.function_name!r} could not '
-                'be parsed. If it predates signature parsing, delete its '
-                'SqlFunDefinition row and re-run makemigrations'
-            ),
+            stored_function.function_name,
         )
         if stored_signature.name in registered_names:
             continue
-        migration_operations[stored_function.app_label].append(migrations.RunSQL(
+        yield stored_function.app_label, migrations.RunSQL(
             sql=f'DROP FUNCTION IF EXISTS {stored_signature.drop_clause};',
             reverse_sql=stored_function.sql_definition,
-        ))
+        )
+
+
+def get_migration_operations() -> dict[str, list[migrations.RunSQL]]:
+    migration_operations = defaultdict(list)
+
+    for sqlfun_cls in SqlFun._registry:
+        operation = _build_operation_for_function(sqlfun_cls)
+        if operation is not None:
+            migration_operations[get_app_label_for_cls(sqlfun_cls)].append(operation)
+
+    for app_label, operation in _build_deleted_function_operations():
+        migration_operations[app_label].append(operation)
 
     return migration_operations
 

--- a/sqlfun/utils.py
+++ b/sqlfun/utils.py
@@ -118,8 +118,6 @@ def get_migration_operations() -> dict[str, list[migrations.RunSQL]]:
         func.get_function_name_from_sql() for func in SqlFun._registry
     }
     for stored_function in SqlFunDefinition.objects.all():
-        if stored_function.function_name in registered_names:
-            continue
         stored_signature = _parse_signature(
             stored_function.sql_definition,
             context=(
@@ -128,6 +126,8 @@ def get_migration_operations() -> dict[str, list[migrations.RunSQL]]:
                 'SqlFunDefinition row and re-run makemigrations'
             ),
         )
+        if stored_signature.name in registered_names:
+            continue
         migration_operations[stored_function.app_label].append(migrations.RunSQL(
             sql=f'DROP FUNCTION IF EXISTS {stored_signature.drop_clause};',
             reverse_sql=stored_function.sql_definition,

--- a/sqlfun/utils.py
+++ b/sqlfun/utils.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 
 from sqlfun.core import SqlFun
 from sqlfun.models import SqlFunDefinition
+from sqlfun.parsing import FunctionSignature, SqlFunParseError, parse_function_signature
 
 if TYPE_CHECKING:
     from django.db.migrations.graph import Node
@@ -33,6 +34,13 @@ def get_previous_sql_definition(cls: SqlFun):
 
 def normalize_sql(sql: str) -> str:
     return sqlparse.format(sql, reindent=True, keyword_case='upper')
+
+
+def _parse_signature(sql: str, context: str) -> FunctionSignature:
+    try:
+        return parse_function_signature(sql)
+    except SqlFunParseError as error:
+        raise SqlFunParseError(f'{context}: {error}') from error
 
 
 def get_app_name(filepath: str) -> str | None:
@@ -62,16 +70,49 @@ def get_migration_operations() -> dict[str, list[migrations.RunSQL]]:
 
     for sqlfun_cls in SqlFun._registry:
         app_label = get_app_label_for_cls(sqlfun_cls)
-        function_name = sqlfun_cls.get_function_name_from_sql()
         current_sql = normalize_sql(sqlfun_cls.sql)
         previous_sql = get_previous_sql_definition(sqlfun_cls)
 
-        if current_sql != previous_sql:
-            drop_function_sql = f'DROP FUNCTION IF EXISTS {function_name};'
-            migration_operations[app_label].append(migrations.RunSQL(
+        if current_sql == previous_sql:
+            continue
+
+        current_signature = _parse_signature(
+            sqlfun_cls.sql,
+            context=f'SqlFun class {sqlfun_cls.__name__!r}',
+        )
+
+        if previous_sql is None:
+            operation = migrations.RunSQL(
                 sql=sqlfun_cls.sql,
-                reverse_sql=previous_sql or drop_function_sql,
-            ))
+                reverse_sql=f'DROP FUNCTION IF EXISTS {current_signature.drop_clause};',
+            )
+        else:
+            previous_signature = _parse_signature(
+                previous_sql,
+                context=(
+                    f'Stored definition for {current_signature.name!r} could not be '
+                    'parsed. If it predates signature parsing, delete its '
+                    'SqlFunDefinition row and re-run makemigrations'
+                ),
+            )
+            if current_signature == previous_signature:
+                operation = migrations.RunSQL(
+                    sql=sqlfun_cls.sql,
+                    reverse_sql=previous_sql,
+                )
+            else:
+                operation = migrations.RunSQL(
+                    sql=[
+                        f'DROP FUNCTION IF EXISTS {previous_signature.drop_clause};',
+                        sqlfun_cls.sql,
+                    ],
+                    reverse_sql=[
+                        f'DROP FUNCTION IF EXISTS {current_signature.drop_clause};',
+                        previous_sql,
+                    ],
+                )
+
+        migration_operations[app_label].append(operation)
 
     for stored_function in SqlFunDefinition.objects.all():
         app_label = stored_function.app_label

--- a/sqlfun/utils.py
+++ b/sqlfun/utils.py
@@ -114,16 +114,24 @@ def get_migration_operations() -> dict[str, list[migrations.RunSQL]]:
 
         migration_operations[app_label].append(operation)
 
+    registered_names = {
+        func.get_function_name_from_sql() for func in SqlFun._registry
+    }
     for stored_function in SqlFunDefinition.objects.all():
-        app_label = stored_function.app_label
-        if not any(
-            func.get_function_name_from_sql() == stored_function.function_name
-            for func in SqlFun._registry
-        ):
-            operation = migrations.RunSQL(
-                sql=f'DROP FUNCTION IF EXISTS {stored_function.function_name};',
-            )
-            migration_operations[app_label].append(operation)
+        if stored_function.function_name in registered_names:
+            continue
+        stored_signature = _parse_signature(
+            stored_function.sql_definition,
+            context=(
+                f'Stored definition for {stored_function.function_name!r} could not '
+                'be parsed. If it predates signature parsing, delete its '
+                'SqlFunDefinition row and re-run makemigrations'
+            ),
+        )
+        migration_operations[stored_function.app_label].append(migrations.RunSQL(
+            sql=f'DROP FUNCTION IF EXISTS {stored_signature.drop_clause};',
+            reverse_sql=stored_function.sql_definition,
+        ))
 
     return migration_operations
 

--- a/tests/test_change_detection.py
+++ b/tests/test_change_detection.py
@@ -298,3 +298,27 @@ def test_reverse_signature_change_restores_old_signature():
         Reversible.deregister()
         for path in migration_paths:
             path.unlink(missing_ok=True)
+
+
+@pytest.mark.django_db
+def test_deleted_function_drop_is_signature_aware_and_reversible():
+    class ToDelete(SqlFun):
+        app_label = 'test_project'
+        sql = """
+            CREATE OR REPLACE FUNCTION to_delete_fn(a integer)
+            RETURNS integer as $$
+            SELECT a;
+            $$ LANGUAGE sql IMMUTABLE;
+        """
+
+    update_sqlfun_definition_model()
+    ToDelete.deregister()
+
+    operations = [
+        op for op in get_migration_operations().get('test_project', [])
+        if 'to_delete_fn' in str(op.sql)
+    ]
+    assert len(operations) == 1
+    operation = operations[0]
+    assert operation.sql == 'DROP FUNCTION IF EXISTS to_delete_fn(a integer);'
+    assert 'CREATE OR REPLACE FUNCTION' in operation.reverse_sql.upper()

--- a/tests/test_change_detection.py
+++ b/tests/test_change_detection.py
@@ -3,6 +3,7 @@ from django.core.management import call_command
 from django.db import connection
 
 from sqlfun import SqlFun
+from sqlfun.models import SqlFunDefinition
 from sqlfun.utils import (
     get_migration_operations,
     make_sqlfun_migrations,
@@ -322,3 +323,41 @@ def test_deleted_function_drop_is_signature_aware_and_reversible():
     operation = operations[0]
     assert operation.sql == 'DROP FUNCTION IF EXISTS to_delete_fn(a integer);'
     assert 'CREATE OR REPLACE FUNCTION' in operation.reverse_sql.upper()
+
+
+@pytest.mark.django_db
+def test_old_format_stored_name_is_not_treated_as_deleted():
+    """Regression test for the pre-branch regex, which preserved case and
+    truncated schema-qualified names down to just the schema. A stored
+    SqlFunDefinition row with such a raw ``function_name`` must still be
+    recognized as matching an unchanged, currently-registered class -- it
+    must not be classified as both new (via current_sql != previous_sql
+    string mismatch is not the trigger here; the parsed-name comparison is)
+    and deleted, which would otherwise emit a DROP that runs after CREATE.
+    """
+
+    class OldFormat(SqlFun):
+        app_label = 'test_project'
+        sql = """
+            CREATE OR REPLACE FUNCTION old_format_fn(a integer)
+            RETURNS integer as $$
+            SELECT a;
+            $$ LANGUAGE sql IMMUTABLE;
+        """
+
+    try:
+        update_sqlfun_definition_model()
+
+        # Simulate a row written by the pre-branch regex: case preserved,
+        # schema-qualified names truncated to just the schema.
+        stored = SqlFunDefinition.objects.get(function_name='old_format_fn')
+        stored.function_name = 'OLD_FORMAT_FN'
+        stored.save()
+
+        drop_ops = [
+            op for op in get_migration_operations().get('test_project', [])
+            if 'old_format_fn' in str(op.sql) and 'DROP FUNCTION' in str(op.sql).upper()
+        ]
+        assert drop_ops == []
+    finally:
+        OldFormat.deregister()

--- a/tests/test_change_detection.py
+++ b/tests/test_change_detection.py
@@ -187,3 +187,114 @@ def test_signature_change_emits_targeted_drop_then_create():
         assert 'CREATE OR REPLACE FUNCTION' in operation.reverse_sql[1].upper()
     finally:
         SigChange.deregister()
+
+
+@pytest.mark.django_db
+def test_change_return_type():
+    class ReturnsInt(SqlFun):
+        app_label = 'test_project'
+        sql = """
+            CREATE OR REPLACE FUNCTION change_return_type_fn(a integer)
+            RETURNS integer as $$
+            SELECT a;
+            $$ LANGUAGE sql IMMUTABLE;
+        """
+
+    migration_paths = []
+    try:
+        migration_paths = make_sqlfun_migrations('change_return_type')
+        call_command('migrate')
+        assert function_exists('change_return_type_fn')
+
+        ReturnsInt.sql = ReturnsInt.sql.replace('RETURNS integer', 'RETURNS bigint')
+        migration_paths.extend(make_sqlfun_migrations('change_return_type_2'))
+        # before this fix, plain CREATE OR REPLACE would fail here with
+        # "cannot change return type of existing function"
+        call_command('migrate')
+
+        assert function_exists('change_return_type_fn')
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT pg_typeof(change_return_type_fn(1))::text")
+            assert cursor.fetchone()[0] == 'bigint'
+    finally:
+        ReturnsInt.deregister()
+        for path in migration_paths:
+            path.unlink(missing_ok=True)
+
+
+@pytest.mark.django_db
+def test_rename_parameter():
+    class Renamed(SqlFun):
+        app_label = 'test_project'
+        sql = """
+            CREATE OR REPLACE FUNCTION rename_param_fn(first integer)
+            RETURNS integer as $$
+            SELECT first;
+            $$ LANGUAGE sql IMMUTABLE;
+        """
+
+    migration_paths = []
+    try:
+        migration_paths = make_sqlfun_migrations('rename_param')
+        call_command('migrate')
+
+        Renamed.sql = """
+            CREATE OR REPLACE FUNCTION rename_param_fn(initial integer)
+            RETURNS integer as $$
+            SELECT initial;
+            $$ LANGUAGE sql IMMUTABLE;
+        """
+        migration_paths.extend(make_sqlfun_migrations('rename_param_2'))
+        # before this fix, plain CREATE OR REPLACE would fail here with
+        # "cannot change name of input parameter"
+        call_command('migrate')
+
+        assert function_exists('rename_param_fn')
+        with connection.cursor() as cursor:
+            cursor.execute('SELECT rename_param_fn(initial := 7)')
+            assert cursor.fetchone()[0] == 7
+    finally:
+        Renamed.deregister()
+        for path in migration_paths:
+            path.unlink(missing_ok=True)
+
+
+@pytest.mark.django_db
+def test_reverse_signature_change_restores_old_signature():
+    class Reversible(SqlFun):
+        app_label = 'test_project'
+        sql = """
+            CREATE OR REPLACE FUNCTION reverse_sig_fn(first integer, second integer)
+            RETURNS integer as $$
+            SELECT first;
+            $$ LANGUAGE sql IMMUTABLE;
+        """
+
+    migration_paths = []
+    try:
+        migration_paths = make_sqlfun_migrations('reverse_sig_v1')
+        call_command('migrate')
+        forward_target = migration_paths[0].stem
+
+        Reversible.sql = Reversible.sql.replace('first integer,', 'first bigint,')
+        migration_paths.extend(make_sqlfun_migrations('reverse_sig_v2'))
+        call_command('migrate')
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT pg_get_function_identity_arguments('reverse_sig_fn'::regproc)"
+            )
+            assert cursor.fetchone()[0] == 'first bigint, second integer'
+
+        call_command('migrate', 'test_project', forward_target)
+
+        assert function_exists('reverse_sig_fn')
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT pg_get_function_identity_arguments('reverse_sig_fn'::regproc)"
+            )
+            assert cursor.fetchone()[0] == 'first integer, second integer'
+    finally:
+        Reversible.deregister()
+        for path in migration_paths:
+            path.unlink(missing_ok=True)

--- a/tests/test_change_detection.py
+++ b/tests/test_change_detection.py
@@ -3,7 +3,11 @@ from django.core.management import call_command
 from django.db import connection
 
 from sqlfun import SqlFun
-from sqlfun.utils import make_sqlfun_migrations
+from sqlfun.utils import (
+    get_migration_operations,
+    make_sqlfun_migrations,
+    update_sqlfun_definition_model,
+)
 
 from .utils import function_exists
 
@@ -109,13 +113,77 @@ def test_change_parameter_number():
     migration_paths.extend(make_sqlfun_migrations('change_parameter_number'))
     call_command('migrate')
 
+    # function_exists counts routines by name, so it is only true when
+    # exactly one overload exists -- the old 2-arg overload must be gone
+    assert function_exists('first_of_two_change_parameter_number')
+
     with connection.cursor() as cursor:
         cursor.execute('SELECT first_of_two_change_parameter_number(1, 2, 3)')
         assert cursor.fetchone()[0] == 1
 
-        # test that exception is raised if we don't pass in the third parameter
-        with pytest.raises(Exception):
-            cursor.execute('SELECT first_of_two_change_parameter_number(1, 2, 3, 4)')
+    # the old 2-arg signature must no longer be callable
+    with pytest.raises(Exception):
+        with connection.cursor() as cursor:
+            cursor.execute('SELECT first_of_two_change_parameter_number(1, 2)')
 
     for path in migration_paths:
         path.unlink()
+
+
+@pytest.mark.django_db
+def test_body_only_change_emits_create_or_replace_without_drop():
+    class BodyOnly(SqlFun):
+        app_label = 'test_project'
+        sql = """
+            CREATE OR REPLACE FUNCTION body_only_fn(a integer)
+            RETURNS integer as $$
+            SELECT a;
+            $$ LANGUAGE sql IMMUTABLE;
+        """
+
+    try:
+        update_sqlfun_definition_model()
+        BodyOnly.sql = BodyOnly.sql.replace('SELECT a;', 'SELECT a + 1;')
+
+        operations = [
+            op for op in get_migration_operations().get('test_project', [])
+            if 'body_only_fn' in str(op.sql)
+        ]
+        assert len(operations) == 1
+        operation = operations[0]
+        assert isinstance(operation.sql, str)
+        assert operation.sql == BodyOnly.sql
+        assert 'DROP FUNCTION' not in operation.sql.upper()
+        assert isinstance(operation.reverse_sql, str)
+        assert 'body_only_fn' in operation.reverse_sql
+    finally:
+        BodyOnly.deregister()
+
+
+@pytest.mark.django_db
+def test_signature_change_emits_targeted_drop_then_create():
+    class SigChange(SqlFun):
+        app_label = 'test_project'
+        sql = """
+            CREATE OR REPLACE FUNCTION sig_change_fn(a integer)
+            RETURNS integer as $$
+            SELECT a;
+            $$ LANGUAGE sql IMMUTABLE;
+        """
+
+    try:
+        update_sqlfun_definition_model()
+        SigChange.sql = SigChange.sql.replace('a integer', 'a bigint')
+
+        operations = [
+            op for op in get_migration_operations().get('test_project', [])
+            if 'sig_change_fn' in str(op.sql)
+        ]
+        assert len(operations) == 1
+        operation = operations[0]
+        assert operation.sql[0] == 'DROP FUNCTION IF EXISTS sig_change_fn(a integer);'
+        assert operation.sql[1] == SigChange.sql
+        assert operation.reverse_sql[0] == 'DROP FUNCTION IF EXISTS sig_change_fn(a bigint);'
+        assert 'CREATE OR REPLACE FUNCTION' in operation.reverse_sql[1].upper()
+    finally:
+        SigChange.deregister()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,4 +1,5 @@
 import pathlib
+from io import StringIO
 from unittest.mock import mock_open, patch
 
 import pytest
@@ -72,3 +73,19 @@ def test_generate_migration_write():
         )
         assert migration_path == expected_path
         mock_file.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_makemigrations_surfaces_parse_errors():
+    class Unparseable(SqlFun):
+        app_label = 'test_project'
+        sql = 'CREATE OR REPLACE FUNCTION broken_fn RETURNS integer AS $$ SELECT 1; $$ LANGUAGE sql;'
+
+    stderr = StringIO()
+    try:
+        call_command('makemigrations', 'test_project', '--dry-run', stderr=stderr)
+        output = stderr.getvalue()
+        assert 'Unparseable' in output
+        assert 'No sqlfun migration was generated' in output
+    finally:
+        Unparseable.deregister()

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -257,6 +257,66 @@ def test_returns_null_on_null_input_does_not_corrupt_return_type():
     assert signature.returns == 'integer'
 
 
+def test_line_comment_between_params_and_returns_is_ignored():
+    signature = parse_function_signature(
+        'CREATE FUNCTION commented(a integer) -- trailing note\n'
+        'RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    assert signature.name == 'commented'
+    assert signature.parameters == (Parameter(definition='a integer'),)
+    assert signature.returns == 'integer'
+
+
+def test_block_comment_between_params_and_returns_is_ignored():
+    signature = parse_function_signature(
+        'CREATE FUNCTION commented(a integer) /* trailing note */ '
+        'RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    assert signature.name == 'commented'
+    assert signature.parameters == (Parameter(definition='a integer'),)
+    assert signature.returns == 'integer'
+
+
+def test_comment_inside_parameter_list_does_not_corrupt_parameters():
+    commented = parse_function_signature("""
+        CREATE FUNCTION commented(
+            a integer, -- the first one
+            b integer /* the second one */
+        ) RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;
+    """)
+    uncommented = parse_function_signature(
+        'CREATE FUNCTION commented(a integer, b integer) '
+        'RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    assert commented.parameters == (
+        Parameter(definition='a integer'),
+        Parameter(definition='b integer'),
+    )
+    assert commented == uncommented
+
+
+def test_comment_like_text_inside_single_quoted_default_is_preserved():
+    signature = parse_function_signature(
+        "CREATE FUNCTION d(a text DEFAULT 'x -- not a comment') "
+        'RETURNS integer AS $$ SELECT 1; $$ LANGUAGE sql;'
+    )
+    assert signature.name == 'd'
+    assert signature.parameters == (Parameter(definition='a text'),)
+    assert signature.returns == 'integer'
+
+
+def test_line_comment_inside_dollar_quoted_body_does_not_affect_parsing():
+    signature = parse_function_signature("""
+        CREATE FUNCTION commented_body(a integer) RETURNS integer AS $$
+            -- this is a real comment inside the function body
+            SELECT a;
+        $$ LANGUAGE sql;
+    """)
+    assert signature.name == 'commented_body'
+    assert signature.parameters == (Parameter(definition='a integer'),)
+    assert signature.returns == 'integer'
+
+
 def test_sqlfun_parse_error_is_a_value_error():
     assert issubclass(SqlFunParseError, ValueError)
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -119,3 +119,105 @@ def test_missing_returns_clause_raises():
 def test_unbalanced_parentheses_raise():
     with pytest.raises(SqlFunParseError):
         parse_function_signature('CREATE FUNCTION broken(a integer RETURNS integer')
+
+
+def test_default_values_are_stripped_and_ignored_for_equality():
+    with_default = parse_function_signature(
+        "CREATE FUNCTION d(a integer DEFAULT 5, b text DEFAULT 'x,y (z)') "
+        'RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    with_eq_default = parse_function_signature(
+        'CREATE FUNCTION d(a integer = 10, b text = NULL) '
+        'RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    without_default = parse_function_signature(
+        'CREATE FUNCTION d(a integer, b text) '
+        'RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    assert with_default == with_eq_default == without_default
+    assert with_default.parameters == (
+        Parameter(definition='a integer'),
+        Parameter(definition='b text'),
+    )
+
+
+def test_parameter_modes_are_parsed():
+    signature = parse_function_signature(
+        'CREATE FUNCTION m(IN a integer, OUT b integer, INOUT c text, VARIADIC nums integer[]) '
+        'RETURNS integer AS $$ SELECT 1; $$ LANGUAGE sql;'
+    )
+    assert signature.parameters == (
+        Parameter(definition='a integer', mode='in'),
+        Parameter(definition='b integer', mode='out'),
+        Parameter(definition='c text', mode='inout'),
+        Parameter(definition='nums integer[]', mode='variadic'),
+    )
+
+
+def test_drop_clause_excludes_out_params_and_keeps_modes():
+    signature = parse_function_signature(
+        'CREATE FUNCTION m(IN a integer, OUT b integer, INOUT c text, VARIADIC nums integer[]) '
+        'RETURNS integer AS $$ SELECT 1; $$ LANGUAGE sql;'
+    )
+    assert signature.drop_clause == 'm(a integer, inout c text, variadic nums integer[])'
+
+
+def test_drop_clause_for_simple_function():
+    signature = parse_function_signature("""
+        CREATE OR REPLACE FUNCTION first_of_two(
+            first integer,
+            second integer
+        ) RETURNS integer as $$ SELECT first; $$ LANGUAGE sql IMMUTABLE;
+    """)
+    assert signature.drop_clause == 'first_of_two(first integer, second integer)'
+
+
+def test_drop_clause_strips_defaults():
+    signature = parse_function_signature(
+        'CREATE FUNCTION d(a integer DEFAULT 5) RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    assert signature.drop_clause == 'd(a integer)'
+
+
+def test_parses_returns_table():
+    signature = parse_function_signature("""
+        CREATE FUNCTION tab(a integer) RETURNS TABLE (
+            id integer,
+            label text
+        ) AS $$ SELECT a, 'x'; $$ LANGUAGE sql;
+    """)
+    assert signature.returns == 'table(id integer,label text)'
+
+
+def test_parses_returns_setof():
+    signature = parse_function_signature(
+        'CREATE FUNCTION s(a integer) RETURNS SETOF integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    assert signature.returns == 'setof integer'
+
+
+def test_parses_multi_word_return_type():
+    signature = parse_function_signature(
+        'CREATE FUNCTION ts(a integer) RETURNS timestamp with time zone '
+        'AS $$ SELECT now(); $$ LANGUAGE sql;'
+    )
+    assert signature.returns == 'timestamp with time zone'
+
+
+def test_quoted_identifiers_preserve_case():
+    signature = parse_function_signature(
+        'CREATE FUNCTION "MixedCase"("Arg" integer) RETURNS integer '
+        'AS $$ SELECT 1; $$ LANGUAGE sql;'
+    )
+    assert signature.name == '"MixedCase"'
+    assert signature.parameters == (Parameter(definition='"Arg" integer'),)
+
+
+def test_body_containing_parens_and_commas_does_not_confuse_parser():
+    signature = parse_function_signature("""
+        CREATE OR REPLACE FUNCTION tricky(a integer) RETURNS integer AS $$
+            SELECT coalesce(a, greatest(1, 2), least(3, 4));
+        $$ LANGUAGE sql;
+    """)
+    assert signature.parameters == (Parameter(definition='a integer'),)
+    assert signature.returns == 'integer'

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,121 @@
+import pytest
+
+from sqlfun.parsing import (
+    FunctionSignature,
+    Parameter,
+    SqlFunParseError,
+    parse_function_signature,
+)
+
+
+def test_parses_simple_function():
+    signature = parse_function_signature("""
+        CREATE OR REPLACE FUNCTION first_of_two(
+            first integer,
+            second integer
+        ) RETURNS integer as $$
+        SELECT first;
+        $$
+        LANGUAGE sql
+        IMMUTABLE;
+    """)
+    assert signature.name == 'first_of_two'
+    assert signature.parameters == (
+        Parameter(definition='first integer'),
+        Parameter(definition='second integer'),
+    )
+    assert signature.returns == 'integer'
+
+
+def test_parses_create_without_or_replace():
+    signature = parse_function_signature(
+        'CREATE FUNCTION no_replace(a integer) RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    assert signature.name == 'no_replace'
+
+
+def test_parses_function_with_no_parameters():
+    signature = parse_function_signature(
+        'CREATE FUNCTION nullary() RETURNS integer AS $$ SELECT 1; $$ LANGUAGE sql;'
+    )
+    assert signature.parameters == ()
+    assert signature.returns == 'integer'
+
+
+def test_parses_parameterized_types_with_nested_parens_and_commas():
+    signature = parse_function_signature(
+        'CREATE FUNCTION money_fn(amount numeric(10, 2)) RETURNS numeric(10, 2) '
+        'AS $$ SELECT amount; $$ LANGUAGE sql;'
+    )
+    assert signature.parameters == (Parameter(definition='amount numeric(10,2)'),)
+    assert signature.returns == 'numeric(10,2)'
+
+
+def test_parses_schema_qualified_name():
+    signature = parse_function_signature(
+        'CREATE FUNCTION public.qualified(a integer) RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    assert signature.name == 'public.qualified'
+
+
+def test_equal_signatures_despite_formatting_differences():
+    compact = parse_function_signature(
+        'create function fmt(first integer,second integer) returns integer as $$ select 1; $$ language sql;'
+    )
+    spread = parse_function_signature("""
+        CREATE OR REPLACE FUNCTION fmt(
+            first   INTEGER,
+            second  INTEGER
+        ) RETURNS INTEGER AS $$ SELECT 2; $$ LANGUAGE sql;
+    """)
+    assert compact == spread
+
+
+def test_different_parameter_type_is_a_different_signature():
+    a = parse_function_signature(
+        'CREATE FUNCTION t(a integer) RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    b = parse_function_signature(
+        'CREATE FUNCTION t(a bigint) RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    assert a != b
+
+
+def test_different_parameter_name_is_a_different_signature():
+    a = parse_function_signature(
+        'CREATE FUNCTION t(a integer) RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    b = parse_function_signature(
+        'CREATE FUNCTION t(b integer) RETURNS integer AS $$ SELECT b; $$ LANGUAGE sql;'
+    )
+    assert a != b
+
+
+def test_different_return_type_is_a_different_signature():
+    a = parse_function_signature(
+        'CREATE FUNCTION t(a integer) RETURNS integer AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    b = parse_function_signature(
+        'CREATE FUNCTION t(a integer) RETURNS bigint AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    assert a != b
+
+
+def test_missing_create_function_raises():
+    with pytest.raises(SqlFunParseError):
+        parse_function_signature('SELECT 1;')
+
+
+def test_missing_parameter_list_raises():
+    with pytest.raises(SqlFunParseError):
+        parse_function_signature('CREATE FUNCTION broken RETURNS integer AS $$ SELECT 1; $$;')
+
+
+def test_missing_returns_clause_raises():
+    with pytest.raises(SqlFunParseError):
+        parse_function_signature('CREATE FUNCTION broken(a integer) AS $$ SELECT a; $$ LANGUAGE sql;')
+
+
+def test_unbalanced_parentheses_raise():
+    with pytest.raises(SqlFunParseError):
+        parse_function_signature('CREATE FUNCTION broken(a integer RETURNS integer')

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,7 +1,7 @@
 import pytest
 
+from sqlfun import SqlFun, SqlFunParseError as ReexportedSqlFunParseError
 from sqlfun.parsing import (
-    FunctionSignature,
     Parameter,
     SqlFunParseError,
     parse_function_signature,
@@ -223,9 +223,6 @@ def test_body_containing_parens_and_commas_does_not_confuse_parser():
     assert signature.returns == 'integer'
 
 
-from sqlfun import SqlFun
-
-
 def test_get_function_name_from_sql_handles_schema_qualified_names():
     class SchemaQualified(SqlFun):
         app_label = 'test_project'
@@ -250,3 +247,19 @@ def test_get_function_name_from_sql_raises_parse_error_naming_the_class():
             Broken.get_function_name_from_sql()
     finally:
         Broken.deregister()
+
+
+def test_returns_null_on_null_input_does_not_corrupt_return_type():
+    signature = parse_function_signature(
+        'CREATE FUNCTION strict_fn(a integer) RETURNS integer '
+        'RETURNS NULL ON NULL INPUT AS $$ SELECT a; $$ LANGUAGE sql;'
+    )
+    assert signature.returns == 'integer'
+
+
+def test_sqlfun_parse_error_is_a_value_error():
+    assert issubclass(SqlFunParseError, ValueError)
+
+
+def test_sqlfun_parse_error_is_importable_from_sqlfun():
+    assert ReexportedSqlFunParseError is SqlFunParseError

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -221,3 +221,32 @@ def test_body_containing_parens_and_commas_does_not_confuse_parser():
     """)
     assert signature.parameters == (Parameter(definition='a integer'),)
     assert signature.returns == 'integer'
+
+
+from sqlfun import SqlFun
+
+
+def test_get_function_name_from_sql_handles_schema_qualified_names():
+    class SchemaQualified(SqlFun):
+        app_label = 'test_project'
+        sql = (
+            'CREATE FUNCTION public.my_func(a integer) RETURNS integer '
+            'AS $$ SELECT a; $$ LANGUAGE sql;'
+        )
+
+    try:
+        assert SchemaQualified.get_function_name_from_sql() == 'public.my_func'
+    finally:
+        SchemaQualified.deregister()
+
+
+def test_get_function_name_from_sql_raises_parse_error_naming_the_class():
+    class Broken(SqlFun):
+        app_label = 'test_project'
+        sql = 'CREATE FUNCTION broken_no_parens RETURNS integer'
+
+    try:
+        with pytest.raises(SqlFunParseError, match='Broken'):
+            Broken.get_function_name_from_sql()
+    finally:
+        Broken.deregister()

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -249,6 +249,16 @@ def test_get_function_name_from_sql_raises_parse_error_naming_the_class():
         Broken.deregister()
 
 
+def test_sql_standard_body_return_after_type_does_not_corrupt_return_type():
+    # PG 14+ SQL-standard bodies imply LANGUAGE SQL, so the LANGUAGE clause
+    # can be omitted and RETURN can directly follow the return type
+    signature = parse_function_signature(
+        'CREATE FUNCTION add_one(a integer) RETURNS integer RETURN a + 1;'
+    )
+    assert signature.returns == 'integer'
+    assert signature.parameters == (Parameter(definition='a integer'),)
+
+
 def test_returns_null_on_null_input_does_not_corrupt_return_type():
     signature = parse_function_signature(
         'CREATE FUNCTION strict_fn(a integer) RETURNS integer '


### PR DESCRIPTION
## Summary

Fixes #7 — changing a function's argument types previously emitted a plain `CREATE OR REPLACE`, which Postgres treats as a new overload, silently orphaning the old one.

- New pure-Python parser (`sqlfun/parsing.py`) extracts a normalized `FunctionSignature` (name, parameters, returns) from each `CREATE FUNCTION` statement; SQL comments in the statement header are stripped before parsing.
- `get_migration_operations` classifies each change: **body-only** changes keep plain `CREATE OR REPLACE` (preserving dependent views, ACLs, ownership); **signature changes** emit a targeted `DROP FUNCTION IF EXISTS name(old args)` + `CREATE`, reversible in both directions.
- Deleting a registered function now generates a signature-aware drop with the stored definition as `reverse_sql` (previously a bare name-only drop with no reverse).
- Unparseable SQL fails loudly: `makemigrations` surfaces `SqlFunParseError` on stderr instead of a generic catch-all. `SqlFunParseError` subclasses `ValueError` (so pre-existing `except ValueError` callers keep working) and is exported from `sqlfun`.
- Deleted-function detection compares parser-normalized names, so stored rows written by the old regex (mixed-case or schema-qualified names) don't cause spurious drops on upgrade.

## Test plan

- 47 tests pass against postgres 16 (`docker compose -f tests/docker-compose.yml up -d && uv run pytest`), including end-to-end integration tests: parameter-count/type/name changes, return-type changes, reverse migrations restoring the old signature, and deletion reversibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)